### PR TITLE
Add teacher auth and enforce roles for register/unregister (#10)

### DIFF
--- a/src/teachers.json
+++ b/src/teachers.json
@@ -1,0 +1,8 @@
+{
+  "teachers": [
+    {
+      "username": "teacher1",
+      "password": "changeme"
+    }
+  ]
+}


### PR DESCRIPTION
Implements a minimal HTTP Basic auth for teacher users using a `src/teachers.json` file and requires authentication for registering/unregistering students. This is an exercise-level implementation (plain-text passwords in JSON) — use hashed passwords and a secure store for production.\n\nChanges:\n- src/app.py: adds HTTP Basic auth, `load_teachers`, and secure endpoints requiring teacher auth\n- src/teachers.json: sample teacher credentials\n\nRelates to issue #10 (Sistema de Roles y Permisos).